### PR TITLE
Use correct separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,7 @@ getAutoPlayer	KEYWORD2
 isGameOver	KEYWORD2
 getGameWinner	KEYWORD2
 getWinLine	KEYWORD2
-getBoardPosition KEYWORD2
+getBoardPosition	KEYWORD2
 
 ######################################
 # Constants/defines (LITERAL1)


### PR DESCRIPTION
The Arduino IDE requires the use of a tab separator between the name and identifier. Without this tab the keyword is not highlighted.

Reference: https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords